### PR TITLE
remove install_prereqs.sh from boot order

### DIFF
--- a/boot-scripts/order.yaml
+++ b/boot-scripts/order.yaml
@@ -5,6 +5,6 @@
 ##   - run_chef.sh
 
 script-order:
-  - install_prereqs.sh
+##  - install_prereqs.sh
   - install_etcd.sh
 


### PR DESCRIPTION
Commented out so we can add later if needed.